### PR TITLE
Post processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ The command will output the following
 Mela2.0 simulator
 
 positional arguments:
-  domain_state_file  A .json file containing the initial state of the
-                     simulation
-  control_file       Simulation control logic as a .yaml file
+  domain_state_file     A .json file containing the initial state of the simulation
+  control_file          Simulation control logic as a .yaml file
+  output_file           Simulator output (pickle) file for alternatives and aggregated data
 
-optional arguments:
-  -h, --help         show this help message and exit
+options:
+  -h, --help            show this help message and exit
+  -s STRATEGY, --strategy STRATEGY
+                        Simulation alternatives tree formation strategy: 'full' (default), 'partial'
 
 ```
 

--- a/app/app_io.py
+++ b/app/app_io.py
@@ -5,5 +5,6 @@ from typing import List
 def parse_cli_arguments(args: List[str]):
     parser = argparse.ArgumentParser(description='Mela2.0 simulator')
     parser.add_argument('domain_state_file', help='A .json file containing the initial state of the simulation')
-    parser.add_argument('control_file', help='Simulation control logic as a .yaml file')
+    parser.add_argument('control_file', help='Simulation control logic as a .yaml file', default='control.yaml')
+    parser.add_argument('output_file', help='Simulator output (pickle) file for alternatives and aggregated data')
     return parser.parse_args(args)

--- a/app/app_io.py
+++ b/app/app_io.py
@@ -7,4 +7,8 @@ def parse_cli_arguments(args: List[str]):
     parser.add_argument('domain_state_file', help='A .json file containing the initial state of the simulation')
     parser.add_argument('control_file', help='Simulation control logic as a .yaml file', default='control.yaml')
     parser.add_argument('output_file', help='Simulator output (pickle) file for alternatives and aggregated data')
+    parser.add_argument('-s', '--strategy',
+                        type=str,
+                        help='Simulation alternatives tree formation strategy: \'full\' (default), \'partial\'',
+                        default='full')
     return parser.parse_args(args)

--- a/app/file_io.py
+++ b/app/file_io.py
@@ -1,5 +1,6 @@
 import json
-from typing import List
+import pickle
+from typing import List, Any, Callable
 import yaml
 from forestdatamodel import ForestStand, ReferenceTree
 
@@ -18,3 +19,13 @@ def forest_stands_from_json_file(file_path: str) -> List[ForestStand]:
 def simulation_declaration_from_yaml_file(file_path: str) -> dict:
     # TODO: content validation
     return yaml.load(file_contents(file_path), Loader=yaml.CLoader)
+
+
+def pickle_writer(file_path: str, data: Any):
+    with open(file_path, 'wb') as f:
+        pickle.dump(data, f, 5)
+
+
+def pickle_reader(file_path: str) -> Any:
+    with open(file_path, 'rb') as f:
+        return pickle.load(f)

--- a/app/file_io.py
+++ b/app/file_io.py
@@ -23,7 +23,7 @@ def simulation_declaration_from_yaml_file(file_path: str) -> dict:
 
 def pickle_writer(file_path: str, data: Any):
     with open(file_path, 'wb') as f:
-        pickle.dump(data, f, 5)
+        pickle.dump(data, f, protocol=5)
 
 
 def pickle_reader(file_path: str) -> Any:

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ import forestry.operations
 from sim.core_types import OperationPayload
 from sim.runners import run_full_tree_strategy, run_partial_tree_strategy
 from forestdatamodel import ForestStand
-from app.file_io import forest_stands_from_json_file, simulation_declaration_from_yaml_file
+from app.file_io import forest_stands_from_json_file, simulation_declaration_from_yaml_file, pickle_writer
 from app.app_io import parse_cli_arguments
 
 
@@ -46,10 +46,12 @@ def main():
     app_arguments = parse_cli_arguments(sys.argv[1:])
     stands = forest_stands_from_json_file(app_arguments.domain_state_file)
     simulation_declaration = simulation_declaration_from_yaml_file(app_arguments.control_file)
+    output_filename = app_arguments.output_file
 
     # run full tree
     full_run_time = int(time.time_ns())
     full_run_result = run_stands(stands, simulation_declaration, run_full_tree_strategy)
+    pickle_writer(output_filename, full_run_result)
     full_run_time = (int(time.time_ns()) - full_run_time) / 1000000000
 
     # run partial trees

--- a/app/main.py
+++ b/app/main.py
@@ -61,13 +61,12 @@ def main():
     output_filename = app_arguments.output_file
     strategy_runner = resolve_strategy_runner(app_arguments.strategy)
 
-    # run full tree
-    full_run_time = int(time.time_ns())
-    full_run_result = run_stands(stands, simulation_declaration, strategy_runner)
-    full_run_time = (int(time.time_ns()) - full_run_time) / 1000000000
-    print_run_result(full_run_result)
-    pickle_writer(output_filename, full_run_result)
-    print("Run in {}".format(full_run_time))
+    run_time = int(time.time_ns())
+    run_result = run_stands(stands, simulation_declaration, strategy_runner)
+    run_time = (int(time.time_ns()) - run_time) / 1000000000
+    print_run_result(run_result)
+    pickle_writer(output_filename, run_result)
+    print("Run in {}".format(run_time))
 
 
 if __name__ == "__main__":

--- a/tests/app/app_io_test.py
+++ b/tests/app/app_io_test.py
@@ -4,10 +4,12 @@ from app import app_io as aio
 
 class TestAppIO(unittest.TestCase):
     def test_app_io(self):
-        args = ['input.json', 'control.yaml']
+        args = ['input.json', 'control.yaml', 'output.pickle', '-s', 'partial']
         result = aio.parse_cli_arguments(args)
         print(result)
         print(dir(result))
-        self.assertEqual(2, len(result.__dict__.keys()))
+        self.assertEqual(4, len(result.__dict__.keys()))
         self.assertEqual('input.json', result.domain_state_file)
         self.assertEqual('control.yaml', result.control_file)
+        self.assertEqual('output.pickle', result.output_file)
+        self.assertEqual('partial', result.strategy)

--- a/tests/app/file_io_test.py
+++ b/tests/app/file_io_test.py
@@ -1,7 +1,16 @@
 import unittest
 import os
 import app.file_io
+from dataclasses import dataclass
 from forestdatamodel import ForestStand, ReferenceTree
+
+
+@dataclass
+class Test:
+    a: int
+
+    def __eq__(self, other):
+        return self.a == other.a
 
 
 class TestFileReading(unittest.TestCase):
@@ -23,3 +32,14 @@ class TestFileReading(unittest.TestCase):
         input_file_path = os.path.join(os.getcwd(), "tests", "resources", "control.yaml")
         result = app.file_io.simulation_declaration_from_yaml_file(input_file_path)
         self.assertEqual(2, len(result.keys()))
+
+    def test_pickle(self):
+        data = [
+            Test(a=1),
+            Test(a=2)
+        ]
+        app.file_io.pickle_writer('testpickle', data)
+        result = app.file_io.pickle_reader('testpickle')
+        self.assertListEqual(data, result)
+        os.remove('testpickle')
+


### PR DESCRIPTION
Closes #38 

Part 1 of post processing:

Added simple Pickle format output functionality to dump result data set into a file. This file can then be simply loaded with the post processing application

Also redesigned the main app to have the alternatives tree formation strategy as a cli argument. Running both strategies in sequence was just for demo purpose.