### PR TITLE
Exclude zero stem trees

### DIFF
--- a/control.yaml
+++ b/control.yaml
@@ -33,6 +33,7 @@ preprocessing_params:
 preprocessing_operations:
   - exclude_sapling_trees
   - exclude_empty_stands
+  - exclude_zero_stem_trees
 
 simulation_events:
   # we describe here objects with schedule for which time points they are active

--- a/forestry/operations.py
+++ b/forestry/operations.py
@@ -5,7 +5,7 @@ from typing import Tuple
 from forestdatamodel.model import ForestStand
 from forestry.grow_acta import grow_acta
 from forestry.r_utils import lmfor_volume
-from forestry.thinning import thinning_from_above, thinning_from_below, report_overall_removal
+from forestry.thinning import first_thinning, thinning_from_above, thinning_from_below, report_overall_removal
 from forestry.aggregate_utils import store_operation_aggregate, get_latest_operation_aggregate
 
 
@@ -44,6 +44,7 @@ operation_lookup = {
     'grow': grow_acta,  # alias for now, maybe make it parametrizable later
     'thinning_from_below': thinning_from_below,
     'thinning_from_above': thinning_from_above,
+    'first_thinning': first_thinning,
     'report_volume': report_volume,
     'report_overall_removal': report_overall_removal
 }

--- a/forestry/preprocessing.py
+++ b/forestry/preprocessing.py
@@ -10,7 +10,13 @@ def exclude_empty_stands(stands: List[ForestStand], **operation_params)-> List[F
     stands = list(filter(lambda s: (s if len(s.reference_trees) > 0 else None), stands))
     return stands
 
+def exclude_zero_stem_trees(stands: List[ForestStand], **operation_params) -> List[ForestStand]:
+    for stand in stands:
+        stand.reference_trees = list(filter(lambda rt: rt.stems_per_ha > 0.0, stand.reference_trees))
+    return stands
+
 operation_lookup = {
     'exclude_sapling_trees': exclude_sapling_trees,
-    'exclude_empty_stands': exclude_empty_stands
+    'exclude_empty_stands': exclude_empty_stands,
+    'exclude_zero_stem_trees': exclude_zero_stem_trees
 }

--- a/sim/operations.py
+++ b/sim/operations.py
@@ -42,6 +42,8 @@ def processor(payload: OperationPayload, operation: typing.Callable, operation_t
     except UserWarning:
         print("Unable to perform operation {}, at time point {}"
             .format(operation_tag, time_point))
+        new_state = payload.simulation_state
+        new_aggregated_results = payload.aggregated_results
 
     new_operation_run_history = {}
     new_operation_run_history['last_run_time_point'] = time_point

--- a/tests/forestry/preprocessing_test.py
+++ b/tests/forestry/preprocessing_test.py
@@ -11,13 +11,14 @@ def generate_stand_with_saplings(sapling_tree_count, reference_tree_count):
         is_sapling = i < sapling_tree_count
         stand.reference_trees.append(ReferenceTree(sapling=is_sapling))
     return stand
-    
+
+
 def generate_empty_stands(stand_count, empty_stand_count):
     stands = []
     for i in range(0, stand_count):
-        stand = ForestStand()  
+        stand = ForestStand()
         stand_is_empty = i < empty_stand_count
-        #if the stand is not meant to be empty, add one Reference tree. 
+        #if the stand is not meant to be empty, add one Reference tree.
         if not stand_is_empty:
             stand.reference_trees.append(ReferenceTree(species=TreeSpecies(1)))
         stands.append(stand)
@@ -42,3 +43,12 @@ class PreprocessingTest(unittest.TestCase):
         stands = generate_empty_stands(stand_count, empty_stand_count)
         excluded = preprocessing.exclude_empty_stands(stands)
         self.assertEqual(len(excluded), stand_count - empty_stand_count)
+
+    def test_exclude_zero_stem_trees(self):
+        fixture = ForestStand()
+        fixture.reference_trees = [
+            ReferenceTree(stems_per_ha=f)
+            for f in [1,2,0,3]
+        ]
+        result = preprocessing.exclude_zero_stem_trees([fixture])
+        self.assertEqual(3, len(result[0].reference_trees))


### PR DESCRIPTION
Problem was that in vmi-data-converter as we use weibull to generate reference trees from single stratum we might end up picking 0.0 stems from the distribution for a single reference tree and for such reference trees the simulation than crashes to division by zero error.

Solution is to filter out such reference trees as a preprocessing step before actual simulation. For this implemented a filtering function and took it into use.

closes #74