### PR TITLE
(Preliminary) data export for J

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ pip install -r requirements.txt
 
 ## Applications
 
-The project contains two application entry points. These are the `app/simulator.py` and the `app/post_processing.py`.
+The project contains three application entry points:
+`app/simulator.py`, `app/post_processing.py` and `app/export.py`.
 The operational details about these applications are documented separately.
 
 ## Usage of the simulator application
@@ -176,6 +177,18 @@ python -m app.post_processing input.pickle pp_control.yaml output.pickle
 * `input.pickle` The result file of a simulator run.
 * `pp_control.yaml` is the declaration of post processing function chain.
 * `output.pickle` is the output file for post processed results
+
+## Usage of the data export application
+
+The data export application can export data from simulation or post-processing results
+to other formats, such as optimizer input files.
+To use it, run
+```
+python -m app.export input.pickle export_control.yaml
+```
+
+* `input.pickle` is the a simulation or post-processing result file.
+* `export_control.yaml` is the export declaration file.
 
 ## Testing
 

--- a/app/app_io.py
+++ b/app/app_io.py
@@ -26,3 +26,10 @@ def post_processing_cli_arguments(args: List[str]):
     parser.add_argument('control_file', help='Post processing control declaration file', default='pp_control.yaml')
     parser.add_argument('output_file', help='Post processing output file')
     return parser.parse_args(args)
+
+
+def export_cli_arguments(args: List[str]):
+    parser = argparse.ArgumentParser(description='Mela2.0 data export')
+    parser.add_argument('input_file', help='Input file (simulator or post processing output)')
+    parser.add_argument('control_file', help='Export control declaration file', default='export_control.yaml')
+    return parser.parse_args(args)

--- a/app/export.py
+++ b/app/export.py
@@ -1,0 +1,127 @@
+import builtins
+from functools import cached_property
+import sys
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+from app.app_io import export_cli_arguments
+from app.file_io import pickle_reader, simulation_declaration_from_yaml_file
+from sim.core_types import OperationPayload
+import numpy as np
+import numpy.typing as npt
+
+
+Decl = Union[str, Dict[str,str], List["Decl"]]
+CollectFn = Callable[[], float]
+
+
+def compile(expr: str, globals: Dict) -> CollectFn:
+    return eval(f"lambda: float({expr})", globals)
+
+
+def _collect_fns(decl: Decl, globals: Dict, out: List[CollectFn]):
+    if isinstance(decl, str):
+        out.append(compile(decl, globals))
+    elif isinstance(decl, dict):
+        for k,v in decl.items():
+            fn = compile(v, globals)
+            fn.name = k
+            out.append(fn)
+    else:
+        for x in decl:
+            _collect_fns(x, globals, out)
+
+
+class CollectFns(dict):
+
+    def __init__(self, decl: Decl):
+        self._fns: List[CollectFn] = []
+        self._globals: Optional[Globals] = None
+        _collect_fns(decl, self, self._fns)
+
+    def __missing__(self, name: str) -> Any:
+        return getattr(self._globals, name)
+
+    def __call__(self, payload: OperationPayload) -> Iterator[float]:
+        self._globals = Globals(payload)
+        for f in self._fns:
+            v = f()
+            if hasattr(f, "name"):
+                setattr(self._globals, f.name, v)
+            yield v
+
+    @cached_property
+    def names(self) -> List[Optional[str]]:
+        return [getattr(f, "name", None) for f in self._fns]
+
+
+class CollectibleNDArray(np.ndarray):
+    def __float__(self) -> float:
+        return float(sum(self))
+
+
+class LazyDataFrame:
+
+    def __init__(self, xs: List):
+        self._xs = xs
+
+    def __getattr__(self, attr: str) -> npt.NDArray:
+        arr = np.array([getattr(x, attr) for x in self._xs]).view(CollectibleNDArray)
+        setattr(self, attr, arr)
+        return arr
+
+
+class Globals:
+
+    def __init__(self, payload: OperationPayload):
+        self._payload = payload
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return getattr(self._payload, name)
+        except AttributeError:
+            pass
+        return getattr(builtins, name)
+
+    @cached_property
+    def trees(self):
+        return LazyDataFrame(self._payload.simulation_state.reference_trees)
+
+    @cached_property
+    def strata(self):
+        return LazyDataFrame(self._payload.simulation_state.tree_strata)
+
+
+def export_j(decl: Dict, data: Dict[str, List[OperationPayload]]):
+    xfns = CollectFns(decl.get("xvariables", []))
+    cfns = CollectFns(decl.get("cvariables", []))
+    xdaout = open(decl.get("xda", "data.xda"), "w")
+    cdaout = open(decl.get("cda", "data.cda"), "w")
+    if all(name is not None for name in xfns.names):
+        xdaout.write(", ".join(xfns.names)) # type: ignore
+        xdaout.write("\n")
+    if all(name is not None for name in cfns.names):
+        cdaout.write(", ".join(["ns", *cfns.names])) # type: ignore
+        cdaout.write("\n")
+    for schedules in data.values():
+        if not schedules:
+            continue
+        cdaout.write("\t".join(map(str, [len(schedules), *cfns(schedules[0])])))
+        cdaout.write("\n")
+        for sched in schedules:
+            xdaout.write("\t".join(map(str, xfns(sched))))
+            xdaout.write("\n")
+    xdaout.close()
+    cdaout.close()
+
+
+def main():
+    args = export_cli_arguments(sys.argv[1:])
+    data = pickle_reader(args.input_file)
+    decl = simulation_declaration_from_yaml_file(args.control_file)
+    format = decl.get("format", "j").lower()
+    if format == "j":
+        export_j(decl, data)
+    else:
+        raise ValueError("Unknown output format: '{}'".format(format))
+
+if __name__ == "__main__":
+    main()

--- a/app/export.py
+++ b/app/export.py
@@ -2,6 +2,8 @@ import builtins
 from functools import cached_property
 import sys
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+
+from forestdatamodel.conversion.internal2mela import TreeSpecies
 from app.app_io import export_cli_arguments
 from app.file_io import pickle_reader, simulation_declaration_from_yaml_file
 from sim.core_types import OperationPayload
@@ -77,6 +79,10 @@ class Globals:
     def __getattr__(self, name: str) -> Any:
         try:
             return getattr(self._payload, name)
+        except AttributeError:
+            pass
+        try:
+            return getattr(TreeSpecies, name)
         except AttributeError:
             pass
         return getattr(builtins, name)

--- a/export_control.yaml
+++ b/export_control.yaml
@@ -1,0 +1,15 @@
+format: J
+
+cvariables:
+  - simulation_state.year
+  - simulation_state.site_type_category
+  - simulation_state.land_use_category
+  - simulation_state.soil_peatland_category
+
+xvariables:
+  # pines and other coniferous
+  - trees.stems_per_ha[(trees.species==1)|(trees.species==8)]
+  # spruces
+  - trees.stems_per_ha[trees.species==2]
+  # deciduous
+  - trees.stems_per_ha[(trees.species>=3)&(trees.species!=8)]

--- a/export_control.yaml
+++ b/export_control.yaml
@@ -11,5 +11,5 @@ xvariables:
   - trees.stems_per_ha[(trees.species==1)|(trees.species==8)]
   # spruces
   - trees.stems_per_ha[trees.species==2]
-  # deciduous
-  - trees.stems_per_ha[(trees.species>=3)&(trees.species!=8)]
+  # deciduous - note: you can also refer to species codes by name (forest-data-model enum coding)
+  - trees.stems_per_ha[(trees.species>=SILVER_BIRCH)&(trees.species!=OTHER_CONIFEROUS)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pyyaml==6.0
 git+https://github.com/menu-hanke/forest-data-model@0.3.2#egg=forestdatamodel
 git+https://github.com/menu-hanke/forestry-function-library@0.1.0#egg=forestryfunctions
 jsonpickle==2.2.0
+numpy==1.23.*
 pandas==1.4.*

--- a/tests/app/app_io_test.py
+++ b/tests/app/app_io_test.py
@@ -19,3 +19,10 @@ class TestAppIO(unittest.TestCase):
         self.assertEqual('input.json', result.input_file)
         self.assertEqual('control.yaml', result.control_file)
         self.assertEqual('output.pickle', result.output_file)
+
+    def test_export_cli_arguments(self):
+        args = ['input.pickle', 'control.yaml']
+        result = aio.export_cli_arguments(args)
+        self.assertEqual(2, len(result.__dict__.keys()))
+        self.assertEqual('input.pickle', result.input_file)
+        self.assertEqual('control.yaml', result.control_file)

--- a/tests/app/export_test.py
+++ b/tests/app/export_test.py
@@ -1,0 +1,24 @@
+import unittest
+from forestdatamodel.enums.internal import TreeSpecies
+from forestdatamodel.model import ForestStand, ReferenceTree
+from app.export import CollectFns
+from sim.core_types import OperationPayload
+
+
+class TestExport(unittest.TestCase):
+    def test_collect(self):
+        collect = CollectFns([
+            "simulation_state.year",
+            "trees.stems_per_ha[trees.species==1]"
+        ])
+        payload = OperationPayload()
+        payload.simulation_state = ForestStand(
+            year = 2022,
+            reference_trees = [
+                ReferenceTree(stems_per_ha=10, species=TreeSpecies.PINE),
+                ReferenceTree(stems_per_ha=20, species=TreeSpecies.SPRUCE),
+                ReferenceTree(stems_per_ha=40, species=TreeSpecies.PINE)
+            ]
+        )
+        values = list(collect(payload))
+        self.assertEqual(values, [2022, 50])


### PR DESCRIPTION
This patch implements a new data exporter entry point, intended to be run after simulation (or post-processing if applicable). It collects variables from output schedules to cda/xda files for J. This is roughly our counterpart to MELA's `COLLECTIVES` and `FOREST_REPORT`.

This is not a complete solution though. Questions to consider:
- MELA's collectives are collected during runtime, while the exporter works on output data. This means the exporter only has access to variable stored in the pickle output. This means we can't do complex collectives such as "total volume of deciduous trees at time points 10, 20 30" without either dumping the full tree vector in the output pickle or moving the collection to runtime.
- If we move collection to runtime, it would probably replace the current "aggregated results"-system, as I don't see a need for both.
- If we move collection to runtime, how do we collect variables from post-processing output? Should collection be able to work both at runtime and on post-processing output?
- Implementing `Pmax`/`Pmin` collectives (max/min values accross branches, _at any point in the simulation_). The current pickle output only contains end states of schedules, so we can't really walk the tree. Maybe either dump a tree structure instead of only end states, or at least enough information to reconstruct the needed parts of the tree?